### PR TITLE
Adding support for mruby 3.x and better `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,55 @@
-TARGET = dreampresent.elf
+# mrbtris: Sample game for Sega Dreamcast written in Ruby
 
-OBJS = src/dreampresent.o src/main.o romdisk.o src/dckos.o
+PROJECT_NAME = dreampresent
 
-# order here is important!
-MRB_SOURCES = src/dc_kos_rb.rb src/page_data.rb src/presentation.rb src/dreampresent.rb src/start.rb
+# Name of the compiled mruby script
+MRB_BYTECODE_IREP_NAME = dreampresent_bytecode
 
-MRB_BYTECODE = src/dreampresent.c
+# Ruby sources
+# The order here is important!
+MRB_SOURCES = src/dc_kos_rb.rb src/page_data.rb src/presentation.rb src/$(PROJECT_NAME).rb src/start.rb
 
+# mruby script output
+MRB_BYTECODE = src/$(PROJECT_NAME).c
+
+# KallistiOS Romdisk directory
 KOS_ROMDISK_DIR = romdisk
 
+# Binary object sources
+OBJS = src/$(PROJECT_NAME).o src/main.o $(KOS_ROMDISK_DIR).o src/dckos.o
+
+# Directory path where mruby is installed
 MRB_ROOT = /opt/mruby
 
+# Compiler flags
 CFLAGS = -I$(MRB_ROOT)/include/ -L$(MRB_ROOT)/build/dreamcast/lib/
 
-all: rm-elf $(TARGET)
+# Program files
+TARGETFILE = $(PROJECT_NAME).elf
+BINARYFILE = $(PROJECT_NAME).bin
+BOOTFILE = cd_root/1ST_READ.BIN
+
+all: rm-elf $(TARGETFILE)
 
 include $(KOS_BASE)/Makefile.rules
 
-clean:
-	-rm -f $(TARGET) $(OBJS) romdisk.* $(MRB_BYTECODE)
-
 rm-elf:
-	-rm -f $(TARGET) romdisk.*
+	-rm -f $(TARGETFILE) $(BINARYFILE) $(BOOTFILE)
 
-$(TARGET): $(OBJS) $(MRB_BYTECODE)
-	kos-cc $(CFLAGS) -o $(TARGET) $(OBJS) -lmruby -lm -lpng -lkosutils -lz
+rm-obj:
+	-rm -f $(OBJS) $(KOS_ROMDISK_DIR).img $(MRB_BYTECODE)
+	
+clean: rm-elf rm-obj
 
-$(MRB_BYTECODE): src/dreampresent.rb
-	$(MRB_ROOT)/bin/mrbc -g -Bdreampresent_bytecode -o src/dreampresent.c $(MRB_SOURCES)
+$(TARGETFILE): $(OBJS) $(MRB_BYTECODE)
+	kos-cc $(CFLAGS) -o $(TARGETFILE) $(OBJS) -lmruby -lm -lpng -lkosutils -lz
+	kos-objcopy -O binary $(TARGETFILE) $(BINARYFILE)
+	
+$(MRB_BYTECODE): $(MRB_SOURCES)
+	$(MRB_ROOT)/bin/mrbc -g -B$(MRB_BYTECODE_IREP_NAME) -o $(MRB_BYTECODE) $(MRB_SOURCES)
 
-run: $(TARGET)
-	$(KOS_LOADER) $(TARGET)
+run: $(TARGETFILE)
+	$(KOS_LOADER) $(TARGETFILE)
 
-dist:
-	rm -f $(OBJS) romdisk.o romdisk.img
-	$(KOS_STRIP) $(TARGET)
+dist: $(TARGETFILE)
+	$(KOS_BASE)/utils/scramble/scramble $(BINARYFILE) $(BOOTFILE)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# mrbtris: Sample game for Sega Dreamcast written in Ruby
+# dreampresent: a simple presentation tool for Sega Dreamcast written in Ruby
 
 PROJECT_NAME = dreampresent
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ The time is currently hardcoded to `35` minutes.
 If you press `Right` on the D-pad, you move the time forward by 5 minutes, and back by 5 minutes if you press `Left`.
 
 ## Building
+
 **Dreampresent** uses [KallistiOS](http://gamedev.allusion.net/softprj/kos/) (KOS) and [mruby](https://mruby.org/) as dependencies. For building this program you have two options: 
 * Using a working KallistiOS setup;
 * Use the provided Docker image below.
 
 The presentation content can be found under `romdisk/` directory, it's embedded when building the program.
+
+**Note:** You will need the `libpng` KallistiOS Ports installed for building this program.
 
 ### Using your KallistiOS environment
 
@@ -35,8 +38,7 @@ Install  `mruby`:
 	cd /opt
 	git clone https://github.com/mruby/mruby.git
 	cd /opt/mruby
-	cp examples/targets/build_config_dreamcast_shelf.rb build_config.rb
-	make
+	make MRUBY_CONFIG=dreamcast_shelf
 
 These commands will produces all the necessary files for using **mruby** on Sega Dreamcast. After that, just navigate to the `dreampresent` directory then enter `make`. This will produces the `dreampresent.elf` file.
 
@@ -65,8 +67,17 @@ If you have the **Lxdream** Sega Dreamcast emulator installed, you can run it wi
 If you want to try this software in your real Dreamcast and/or in an emulator, you may create a **Padus DiscJuggler** (`cdi`) image. For example, if you are using [DreamSDK](https://dreamsdk.org), you may do the following:
 
 	make dist
-	elf2bin dreampresent.elf
-	scramble dreampresent.bin cd_root/1ST_READ.BIN
 	makedisc dreampresent.cdi cd_root
 
 This will produces the `dreampresent.cdi` image file that you may burn onto a CD-R or use in a Dreamcast Emulator.
+
+### Using dcload/dc-tool (part of KallistiOS)
+
+If you have a [Coders Cable](https://dreamcast.wiki/Coder%27s_cable) or a [Broadband Adapter](https://dreamcast.wiki/Broadband_adapter) (BBA) / [LAN Adapter](https://dreamcast.wiki/LAN_adapter), you could also the `dcload` program (part of **KallistiOS**) to load it directly on the Sega Dreamcast. It should load as a normal Sega Dreamcast program.
+
+To do that, you may enter the following:
+
+	make run
+
+This will execute `dc-tool` using the `dreampresent.elf` binary file as target.
+

--- a/src/dckos.c
+++ b/src/dckos.c
@@ -2,6 +2,7 @@
 #include <kos.h>
 #include <kos/img.h>
 #include <mruby.h>
+#include <mruby/internal.h>
 #include <mruby/data.h>
 #include <mruby/string.h>
 #include <mruby/error.h>


### PR DESCRIPTION
This PR was made for the following changes:

- Adding support for mruby 3.x (backward compatible with mruby 2.x)
- Better `Makefile` (build `BIN` binary file at the same time of the `ELF` binary file)
- Better `README.md`